### PR TITLE
Refactor anonymize-data endpoint with DTO and role-based access

### DIFF
--- a/src/anonymization/controllers/anonymization.controller.ts
+++ b/src/anonymization/controllers/anonymization.controller.ts
@@ -1,10 +1,15 @@
-import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
 import { AnonymizationService } from '../services/anonymization.service';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
-import { Role } from '../../auth/roles.enum';
-// import { Role } from '../../auth/enums/role.enum';
+import { Role } from '../../auth/roles.enum'; // keep using this path if it works
+import { AnonymizeDataDto } from '../dto/anonymize-data.dto';
 
 @Controller('anonymization')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -13,10 +18,9 @@ export class AnonymizationController {
 
   @Post('anonymize-data')
   @Roles(Role.ADMIN)
-  async anonymizeData(
-    @Body() body: { data: Record<string, any>; fieldsToAnonymize: string[] },
-  ) {
-    const { data, fieldsToAnonymize } = body;
-    return this.anonymizationService.anonymizeFields(data, fieldsToAnonymize);
+  async anonymizeData(@Body() dto: AnonymizeDataDto) {
+    const { data, fieldsToAnonymize } = dto;
+    const result = await this.anonymizationService.anonymizeFields(data, fieldsToAnonymize);
+    return { message: 'Data anonymized successfully', result };
   }
 }

--- a/src/anonymization/dto/anonymize-data.dto.ts
+++ b/src/anonymization/dto/anonymize-data.dto.ts
@@ -1,0 +1,11 @@
+import { IsObject, IsArray, IsString, ArrayNotEmpty } from 'class-validator';
+
+export class AnonymizeDataDto {
+  @IsObject()
+  data: Record<string, any>;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  fieldsToAnonymize: string[];
+}


### PR DESCRIPTION
### Changes I have made
- Removed old `@Post('anonymize-data')` implementation
- Rebuilt with a type-safe DTO using `class-validator`
- Added basic validation for data and fieldsToAnonymize
- Ensured endpoint is accessible only to `Role.ADMIN` using `@Roles()` and `RolesGuard`
- Reused existing service method `anonymizeFields()` without changes

### Why
- Previous version had type compatibility issues with the Role enum
- Aligning with clean NestJS architecture and improving maintainability

### Test
- [x] Validated with realistic payloads
- [x] Rejected invalid requests with proper error messages

closes #135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added input validation for anonymization requests, ensuring required fields are present and correctly formatted.
- **Refactor**
  - Improved the structure of anonymization request handling for clearer responses and better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->