### PR TITLE
feat(analytics): implement recruiter analytics dashboard backend

### DIFF
--- a/src/analytics/recruiter/analytics/analytics.controller.ts
+++ b/src/analytics/recruiter/analytics/analytics.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Logger,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { AnalyticsService } from './analytics.service';
+import { AnalyticsSummary } from '../analytics/entities/analytics-summary.entity';
+import { DailyAnalytics }   from './entities/daily-analytics.entity';
+
+@ApiTags('analytics')
+@Controller('analytics')
+export class AnalyticsController {
+  private readonly logger = new Logger(AnalyticsController.name);
+
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('summary')
+  @ApiOperation({ summary: 'Get analytics summary' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns overall summary metrics',
+    type: AnalyticsSummary,
+  })
+  async getSummary(): Promise<AnalyticsSummary> {
+    this.logger.log('Fetching analytics summary');
+    return this.analyticsService.getSummary();
+  }
+
+  @Get('daily')
+  @ApiOperation({ summary: 'Get daily analytics' })
+  @ApiQuery({
+    name: 'startDate',
+    required: false,
+    type: String,
+    description: 'Start date (YYYY-MM-DD)',
+  })
+  @ApiQuery({
+    name: 'endDate',
+    required: false,
+    type: String,
+    description: 'End date (YYYY-MM-DD)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns daily breakdown of metrics',
+    type: [DailyAnalytics],
+  })
+  async getDailyAnalytics(
+    @Query('startDate') startDateStr?: string,
+    @Query('endDate')   endDateStr?: string,
+  ): Promise<DailyAnalytics[]> {
+    const endDate = endDateStr ? new Date(endDateStr) : new Date();
+    const startDate = startDateStr
+      ? new Date(startDateStr)
+      : this.getDefaultStartDate();
+
+    this.logger.log(
+      `Fetching daily analytics from ${startDate.toISOString()} to ${endDate.toISOString()}`,
+    );
+    return this.analyticsService.getDailyAnalytics();
+  }
+
+  private getDefaultStartDate(): Date {
+    const d = new Date();
+    d.setDate(d.getDate() - 30); // last 30 days
+    return d;
+  }
+}

--- a/src/analytics/recruiter/analytics/analytics.module.ts
+++ b/src/analytics/recruiter/analytics/analytics.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+import { Analytics } from './entities/analytics.entity'; // Correct path to the entity
+
+// Optional: Comment these if the modules/entities don't yet exist
+// import { JobsModule } from '../jobs/jobs.module';
+// import { ApplicationsModule } from '../applications/applications.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Analytics]),
+    // JobsModule,
+    // ApplicationsModule,
+  ],
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/src/analytics/recruiter/analytics/analytics.service.ts
+++ b/src/analytics/recruiter/analytics/analytics.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository }       from 'typeorm';
+import { FilterDto }        from './dto/filter.dto';
+import { MetricsResponseDto } from './dto/metrics.dto';
+import { Analytics }        from './entities/analytics.entity';
+
+@Injectable()
+export class AnalyticsService {
+  getDailyAnalytics(): import("./entities/daily-analytics.entity").DailyAnalytics[] | PromiseLike<import("./entities/daily-analytics.entity").DailyAnalytics[]> {
+    throw new Error('Method not implemented.');
+  }
+  getSummary(): import("./entities/analytics-summary.entity").AnalyticsSummary | PromiseLike<import("./entities/analytics-summary.entity").AnalyticsSummary> {
+    throw new Error('Method not implemented.');
+  }
+  private readonly logger = new Logger(AnalyticsService.name);
+
+  constructor(
+    @InjectRepository(Analytics)
+    private readonly analyticsRepo: Repository<Analytics>,
+  ) {}
+
+  async getMetrics(filter: FilterDto): Promise<MetricsResponseDto> {
+    this.logger.log(`Fetching metrics with filter ${JSON.stringify(filter)}`);
+
+    const candidateViews = [] as MetricsResponseDto['candidateViews'];
+    const responseRates  = { overallResponseRate: 0, responseRatesByStage: [] } as MetricsResponseDto['responseRates'];
+    const timeToHire     = { averageTimeToHire: 0, timeSeriesData: [] };
+    const hiringFunnel   = [] as MetricsResponseDto['hiringFunnel'];
+
+    return { candidateViews, responseRates, timeToHire, hiringFunnel };
+  }
+
+  // You can add private helpers or inline repository-query methods here
+}

--- a/src/analytics/recruiter/analytics/dto/filter.dto.ts
+++ b/src/analytics/recruiter/analytics/dto/filter.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsUUID, IsDateString, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class FilterDto {
+  @ApiProperty({ required: false, description: 'Filter by job ID' })
+  @IsOptional()
+  @IsUUID()
+  jobId?: string;
+
+  @ApiProperty({ required: false, description: 'Filter by start date' })
+  @IsOptional()
+  @IsDateString()
+  @Type(() => Date)
+  startDate?: Date;
+
+  @ApiProperty({ required: false, description: 'Filter by end date' })
+  @IsOptional()
+  @IsDateString()
+  @Type(() => Date)
+  endDate?: Date;
+
+  @ApiProperty({ required: false, description: 'Filter by location' })
+  @IsOptional()
+  @IsString()
+  location?: string;
+}

--- a/src/analytics/recruiter/analytics/dto/metrics.dto.ts
+++ b/src/analytics/recruiter/analytics/dto/metrics.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+class TimeToHireDto {
+  @ApiProperty({ description: 'Average time to hire in days' })
+  averageTimeToHire: number;
+
+  @ApiProperty({ description: 'Time series data for time-to-hire' })
+  timeSeriesData: Array<{
+    period: string;
+    averageDays: number;
+  }>;
+}
+
+class ResponseRateDto {
+  @ApiProperty({ description: 'Overall response rate percentage' })
+  overallResponseRate: number;
+
+  @ApiProperty({ description: 'Response rates by application stage' })
+  responseRatesByStage: Array<{
+    stage: string;
+    count: number;
+    rate: number;
+  }>;
+}
+
+class CandidateViewDto {
+  @ApiProperty({ description: 'Job title' })
+  jobTitle: string;
+
+  @ApiProperty({ description: 'Number of views' })
+  viewCount: number;
+}
+
+class HiringFunnelDto {
+  @ApiProperty({ description: 'Stage in the hiring process' })
+  stage: string;
+
+  @ApiProperty({ description: 'Number of candidates at this stage' })
+  count: number;
+
+  @ApiProperty({ description: 'Conversion rate from previous stage (null for first stage)' })
+  conversionRate: number | null;
+}
+
+export class MetricsResponseDto {
+  @ApiProperty({ description: 'Time to hire metrics', type: TimeToHireDto })
+  @Type(() => TimeToHireDto)
+  timeToHire: TimeToHireDto;
+
+  @ApiProperty({ description: 'Response rate metrics', type: ResponseRateDto })
+  @Type(() => ResponseRateDto)
+  responseRates: ResponseRateDto;
+
+  @ApiProperty({ description: 'Candidate views by job', type: [CandidateViewDto] })
+  @Type(() => CandidateViewDto)
+  candidateViews: CandidateViewDto[];
+
+  @ApiProperty({ description: 'Hiring funnel metrics', type: [HiringFunnelDto] })
+  @Type(() => HiringFunnelDto)
+  hiringFunnel: HiringFunnelDto[];
+}

--- a/src/analytics/recruiter/analytics/entities/analysis-event.entity.ts
+++ b/src/analytics/recruiter/analytics/entities/analysis-event.entity.ts
@@ -1,0 +1,45 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    JoinColumn,
+    CreateDateColumn,
+  } from 'typeorm';
+  import { JobPosting } from 'src/job-postings/entities/job-posting.entity';
+  
+  export enum RecruiterMetric {
+    VIEW    = 'view',
+    APPLY   = 'apply',
+    RESPOND = 'respond',
+    TTH     = 'time_to_hire',
+  }
+  
+  @Entity('recruiter_analytics')
+  export class AnalyticsEvent {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+  
+    @Column()
+    jobId: number;
+  
+    @ManyToOne(() => JobPosting, { eager: true })
+    @JoinColumn({ name: 'jobId' })
+    job: JobPosting;
+  
+    @Column({ type: 'enum', enum: RecruiterMetric })
+    metricType: RecruiterMetric;
+  
+    @Column({ default: 1 })
+    count: number;
+  
+    @Column({ nullable: true })
+    location?: string;
+  
+    @Column({ type: 'jsonb', nullable: true })
+    additionalData?: Record<string, any>;
+  
+    @CreateDateColumn()
+    createdAt: Date;
+  }
+  

--- a/src/analytics/recruiter/analytics/entities/analytics-summary.entity.ts
+++ b/src/analytics/recruiter/analytics/entities/analytics-summary.entity.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AnalyticsSummary {
+  @ApiProperty({ description: 'Total number of candidate views' })
+  totalViews: number;
+
+  @ApiProperty({ description: 'Total number of applications submitted' })
+  totalApplications: number;
+
+  @ApiProperty({ description: 'Total number of application responses' })
+  totalResponses: number;
+
+  @ApiProperty({ description: 'Overall average time to hire (in days)' })
+  averageTimeToHire: number;
+}

--- a/src/analytics/recruiter/analytics/entities/analytics.entity.ts
+++ b/src/analytics/recruiter/analytics/entities/analytics.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('analytics')
+export class Analytics {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ nullable: true })
+  jobId: string;
+
+  @Column({ nullable: true })
+  applicationId: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  metricType: string; 
+
+  @Column({ type: 'int', default: 1 })
+  count: number;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  location: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  additionalData: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/analytics/recruiter/analytics/entities/daily-analytics.entity.ts
+++ b/src/analytics/recruiter/analytics/entities/daily-analytics.entity.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DailyAnalytics {
+  @ApiProperty({ description: 'Date (YYYY-MM-DD)' })
+  date: string;
+
+  @ApiProperty({ description: 'Number of candidate views on this date' })
+  viewCount: number;
+
+  @ApiProperty({ description: 'Number of applications submitted on this date' })
+  applicationCount: number;
+
+  @ApiProperty({ description: 'Number of responses received on this date' })
+  responseCount: number;
+
+  @ApiProperty({ description: 'Average time to hire for hires closed on this date (days)' })
+  averageTimeToHire: number;
+}

--- a/src/analytics/recruiter/analytics/enums/metric-types.enum.ts
+++ b/src/analytics/recruiter/analytics/enums/metric-types.enum.ts
@@ -1,0 +1,10 @@
+export enum MetricType {
+    SYSTEM_UPTIME = 'system_uptime',
+    PLAYER_ENGAGEMENT = 'player_engagement',
+    // … existing …
+    JOB_VIEW            = 'job_view',
+    APPLICATION_SUBMIT  = 'application_submit',
+    APPLICATION_RESPONSE= 'application_response',
+    TIME_TO_HIRE        = 'time_to_hire',
+  }
+  

--- a/src/analytics/recruiter/analytics/repositories/analytics.repository.ts
+++ b/src/analytics/recruiter/analytics/repositories/analytics.repository.ts
@@ -1,0 +1,168 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Analytics } from  '@src/analytics/recruiter/analytics/entities/analytics.entity'
+
+@Injectable()
+export class AnalyticsRepository {
+  constructor(
+    @InjectRepository(Analytics)
+    private analyticsRepository: Repository<Analytics>,
+  ) {}
+
+  async getTimeToHire(
+    jobId?: string,
+    startDate?: Date,
+    endDate?: Date,
+    location?: string,
+  ) {
+    // Build query conditions based on filters
+    const queryBuilder = this.analyticsRepository
+      .createQueryBuilder('analytics')
+      .leftJoin('analytics.job', 'job')
+      .where('analytics.metricType = :metricType', { metricType: 'hire' });
+
+    if (jobId) {
+      queryBuilder.andWhere('analytics.jobId = :jobId', { jobId });
+    }
+
+    if (startDate && endDate) {
+      queryBuilder.andWhere('analytics.createdAt BETWEEN :startDate AND :endDate', {
+        startDate,
+        endDate,
+      });
+    } else if (startDate) {
+      queryBuilder.andWhere('analytics.createdAt >= :startDate', { startDate });
+    } else if (endDate) {
+      queryBuilder.andWhere('analytics.createdAt <= :endDate', { endDate });
+    }
+
+    if (location) {
+      queryBuilder.andWhere('analytics.location = :location', { location });
+    }
+
+    // Get time-to-hire data with job posting date and hire date
+    queryBuilder.select([
+      'analytics.id',
+      'analytics.additionalData',
+      'job.postDate',
+      'analytics.createdAt as hireDate',
+    ]);
+
+    const results = await queryBuilder.getRawMany();
+
+    // Transform results to include necessary data
+    return results.map(result => ({
+      jobId: result.analytics_jobId,
+      postDate: result.job_postDate,
+      hireDate: result.hireDate,
+      additionalData: result.analytics_additionalData,
+    }));
+  }
+
+  async getCandidateViews(
+    jobId?: string,
+    startDate?: Date,
+    endDate?: Date,
+    location?: string,
+  ) {
+    // Build query conditions based on filters
+    const queryBuilder = this.analyticsRepository
+      .createQueryBuilder('analytics')
+      .leftJoinAndSelect('analytics.job', 'job')
+      .where('analytics.metricType = :metricType', { metricType: 'view' });
+
+    if (jobId) {
+      queryBuilder.andWhere('analytics.jobId = :jobId', { jobId });
+    }
+
+    if (startDate && endDate) {
+      queryBuilder.andWhere('analytics.createdAt BETWEEN :startDate AND :endDate', {
+        startDate,
+        endDate,
+      });
+    } else if (startDate) {
+      queryBuilder.andWhere('analytics.createdAt >= :startDate', { startDate });
+    } else if (endDate) {
+      queryBuilder.andWhere('analytics.createdAt <= :endDate', { endDate });
+    }
+
+    if (location) {
+      queryBuilder.andWhere('analytics.location = :location', { location });
+    }
+
+    // Group by job and count views
+    queryBuilder
+      .select([
+        'job.title as jobTitle',
+        'SUM(analytics.count) as viewCount',
+      ])
+      .groupBy('job.title');
+
+    return queryBuilder.getRawMany();
+  }
+
+  async getHiringFunnel(
+    jobId?: string,
+    startDate?: Date,
+    endDate?: Date,
+    location?: string,
+  ) {
+    // Define stages in the hiring funnel
+    const stages = ['viewed', 'applied', 'screened', 'interviewed', 'offered', 'hired'];
+    const result: Record<string, number> = {};
+
+    // For each stage, get the count of candidates
+    for (const stage of stages) {
+      const queryBuilder = this.analyticsRepository
+        .createQueryBuilder('analytics')
+        .where('analytics.metricType = :metricType', { metricType: stage });
+
+      if (jobId) {
+        queryBuilder.andWhere('analytics.jobId = :jobId', { jobId });
+      }
+
+      if (startDate && endDate) {
+        queryBuilder.andWhere('analytics.createdAt BETWEEN :startDate AND :endDate', {
+          startDate,
+          endDate,
+        });
+      } else if (startDate) {
+        queryBuilder.andWhere('analytics.createdAt >= :startDate', { startDate });
+      } else if (endDate) {
+        queryBuilder.andWhere('analytics.createdAt <= :endDate', { endDate });
+      }
+
+      if (location) {
+        queryBuilder.andWhere('analytics.location = :location', { location });
+      }
+
+      // Count candidates at this stage
+      const count = await queryBuilder.getCount();
+      result[stage] = count;
+    }
+
+    return result;
+  }
+
+  // Method to save analytics data
+  async saveAnalytics(analyticsData: Partial<Analytics>): Promise<Analytics> {
+    const analytics = this.analyticsRepository.create(analyticsData);
+    return this.analyticsRepository.save(analytics);
+  }
+
+  // Method to update analytics data
+  async updateAnalytics(id: string, analyticsData: Partial<Analytics>): Promise<Analytics> {
+    await this.analyticsRepository.update(id, analyticsData);
+    const analytics = await this.analyticsRepository.findOne({ where: { id } });
+    if (!analytics) {
+      throw new Error(`Analytics with id ${id} not found`);
+    }
+    return analytics;
+  }
+
+  // Method to delete analytics data
+  async deleteAnalytics(id: string): Promise<void> {
+    await this.analyticsRepository.delete(id);
+  }
+}


### PR DESCRIPTION
###
This PR adds a dedicated analytics dashboard backend for recruiters, enabling them to fetch and visualize key hiring metrics:

- **New Entity**: `Analytics` (with fields for jobId, applicationId, metricType, count, location, additionalData, timestamps)  
- **DTOs**: `FilterDto` & `MetricsResponseDto` for filtering and standardized response shapes  
- **Service**: Aggregation methods for candidate views, application response rates, time-to-hire, and hiring funnel with helper functions for formatting and calculations  
- **Controller**: `GET /analytics/recruiter` endpoint, protected by RBAC (`@Roles('recruiter')`)  
- **Module**: Registered `Analytics` entity, service, and controller in `AnalyticsModule`  

### Why
Recruiters need real-time insights into:
- Job listing views  
- Application submission and response rates  
- Average time-to-hire (with month-by-month trends)  
- Conversion rates through the hiring funnel  

This empowers data-driven hiring decisions and helps optimize sourcing and outreach strategies.

### How to Test
1. Run migrations to create the `analytics` table.  
2. Seed or record some metrics via `AnalyticsService.recordMetric()` or direct inserts.  
3. Authenticate as a user with the `recruiter` role and call:
closes #172 