### PR TITLE
feat: integrate external API with retry logic, exponential backoff, and fallback

### DIFF
--- a/src/external-api/external-api.module.ts
+++ b/src/external-api/external-api.module.ts
@@ -1,0 +1,25 @@
+// src/external-api/external-api.module.ts
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { ExternalApiService } from './services/external-api.service';
+import { RetryInterceptor } from '../interceptors/retry.interceptor';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+
+@Module({
+  imports: [
+    HttpModule.register({
+      timeout: 5000,
+      maxRedirects: 5,
+    }),
+  ],
+  providers: [
+    ExternalApiService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: RetryInterceptor,
+    },
+  ],
+  exports: [ExternalApiService],
+})
+export class ExternalApiModule {}
+

--- a/src/external-api/external-api.service.ts
+++ b/src/external-api/external-api.service.ts
@@ -1,0 +1,56 @@
+// src/external-api/services/external-api.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { catchError, lastValueFrom, map, retryWhen, scan, delay } from 'rxjs';
+import { AxiosError } from 'axios';
+
+@Injectable()
+export class ExternalApiService {
+  private readonly logger = new Logger(ExternalApiService.name);
+
+  constructor(private readonly httpService: HttpService) {}
+
+  async callExternalApi(endpoint: string): Promise<any> {
+    try {
+      const response$ = this.httpService.get(endpoint).pipe(
+        retryWhen(errors =>
+          errors.pipe(
+            scan((retryCount, error) => {
+              const maxRetries = 5;
+              if (retryCount >= maxRetries || !this.shouldRetry(error)) {
+                throw error;
+              }
+              const backoffTime = Math.pow(2, retryCount) * 1000;
+              this.logger.warn(`Retrying [${retryCount + 1}] after ${backoffTime}ms...`);
+              return retryCount + 1;
+            }, 0),
+            delay(retryCount => Math.pow(2, retryCount) * 1000)
+          )
+        ),
+        map(res => res.data),
+        catchError((error: AxiosError) => {
+          this.logger.error(`Final failure calling API: ${error.message}`);
+          return [this.fallbackResponse(endpoint)];
+        })
+      );
+
+      return await lastValueFrom(response$);
+    } catch (err) {
+      this.logger.error(`Unhandled error in external call: ${err.message}`);
+      return this.fallbackResponse(endpoint);
+    }
+  }
+
+  private shouldRetry(error: any): boolean {
+    if (!error.response) return true; // network error
+    const retryStatusCodes = [429, 503, 504];
+    return retryStatusCodes.includes(error.response.status);
+  }
+
+  private fallbackResponse(endpoint: string) {
+    return {
+      success: false,
+      message: `Fallback: Could not reach external API at ${endpoint}`,
+    };
+  }
+}

--- a/src/interceptors/retry.interceptor.ts
+++ b/src/interceptors/retry.interceptor.ts
@@ -1,0 +1,36 @@
+// src/interceptors/retry.interceptor.ts
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, throwError, retryWhen, scan, delay } from 'rxjs';
+import { Request } from 'express';
+
+@Injectable()
+export class RetryInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const url = request.url;
+
+    return next.handle().pipe(
+      retryWhen(errors =>
+        errors.pipe(
+          scan((retryCount, error) => {
+            const maxRetries = 3;
+            if (retryCount >= maxRetries) {
+              throw error;
+            }
+            const backoffTime = Math.pow(2, retryCount) * 1000;
+            console.warn(
+              `Retrying ${url} [Attempt ${retryCount + 1}] after ${backoffTime}ms...`
+            );
+            return retryCount + 1;
+          }, 0),
+          delay(retryCount => Math.pow(2, retryCount) * 1000)
+        )
+      )
+    );
+  }
+}


### PR DESCRIPTION
# 🔄 External API Integration with Retry Logic for StarkHive

## Summary

This PR integrates an external API (e.g., payment gateway) into StarkHive with a robust retry mechanism, exponential backoff, and graceful fallback handling.

## Features

- ✅ External API connection via `HttpModule` and `HttpService`
- 🔁 Automatic retries with exponential backoff (up to 5 attempts)
- ⚠️ Handles rate limits (429), service unavailability (503), and network errors
- 🪵 Comprehensive logging of retries and errors
- 🛡️ Fallback response when all retries fail
- 🧠 Global retry interceptor to handle resilience across requests

## Files Added/Modified

- `external-api.module.ts`
- `external-api.service.ts`
- `interceptors/retry.interceptor.ts`

## Test Suggestions

- Simulate 429 or 503 responses from external service
- Observe retry logs and final fallback behavior
- Ensure resilience under network failure scenarios

## Closes

Closes #174 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new module for handling external API requests with built-in timeout and redirect limits.
  - Added a service that performs HTTP GET requests to external APIs, including automatic retries with exponential backoff and fallback responses for failures.
  - Implemented a global interceptor that automatically retries failed HTTP requests up to three times with exponential backoff and detailed logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->